### PR TITLE
Updating Pivotal urls for stories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.suo
+_ReSharper*

--- a/PivotalTrackerAPI/Domain/Model/PivotalMembershipList.cs
+++ b/PivotalTrackerAPI/Domain/Model/PivotalMembershipList.cs
@@ -24,7 +24,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// Constructor
     /// </summary>
     /// <param name="members">The members associated with the group</param>
-    public PivotalMembershipList(IList<PivotalMembership> members)
+    public PivotalMembershipList(List<PivotalMembership> members)
     {
       Memberships = members;
     }

--- a/PivotalTrackerAPI/Domain/Model/PivotalNote.cs
+++ b/PivotalTrackerAPI/Domain/Model/PivotalNote.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Serialization;
+using PivotalTrackerAPI.Domain.Services;
+using PivotalTrackerAPI.Util;
+
+namespace PivotalTrackerAPI.Domain.Model
+{
+    [XmlRoot("note")]
+    public class PivotalNote
+    {
+        public PivotalNote() { }
+
+        #region Private Properties
+
+        private string _creationDateString;
+        private DateTime _creationDate;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// The id of the note
+        /// </summary>
+        [XmlElement("id", IsNullable = true)]
+        public Nullable<int> NoteId { get; set; }
+
+        /// <summary>
+        /// The content of the note
+        /// </summary>
+        [XmlElement("text")]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// The author of the note
+        /// </summary>
+        [XmlElement("author")]
+        public string Author { get; set; }
+
+        /// <summary>
+        /// The string representing the date the note was created (as returned by Pivotal).  See CreationDate for the value
+        /// </summary>
+        [XmlElement("noted_at", IsNullable = true)]
+        public string CreationDateString
+        {
+            get
+            {
+                return _creationDateString;
+            }
+            set
+            {
+                _creationDateString = value;
+                if (value != null && value.Length > 4)
+                {
+                    try
+                    {
+                        CreationDate = DateTime.ParseExact(value.Substring(0, value.Length - 4), "yyyy/MM/dd hh:mm:ss", new System.Globalization.CultureInfo("en-US", true), System.Globalization.DateTimeStyles.NoCurrentDateDefault);
+                    }
+                    catch
+                    {
+                        CreationDate = new DateTime();
+                    }
+                }
+                else
+                    CreationDate = new DateTime();
+            }
+        }
+
+        #endregion
+
+        #region Non-Pivotal Properties (helpers)
+
+        /// <summary>
+        /// The date the task was created
+        /// </summary>
+        [XmlIgnore]
+        public DateTime CreationDate
+        {
+            get
+            {
+                return _creationDate;
+            }
+            set
+            {
+                _creationDate = value;
+                _creationDateString = _creationDate.ToString("yyyy/MM/dd hh:mm:ss") + " UTC";
+            }
+        }
+
+        #endregion
+
+        public static IList<PivotalNote> FetchNotes(PivotalUser user, int projectId, int storyId, string filter)
+        {
+            var url = String.Format("{0}/projects/{1}/stories/{2}/notes?token={3}", PivotalService.BaseUrl, projectId, storyId, user.ApiToken);
+            if (!string.IsNullOrEmpty(filter))
+                url += "&" + filter;
+            var xmlDoc = PivotalService.GetData(url);
+            var noteList = SerializationHelper.DeserializeFromXmlDocument<PivotalNoteList>(xmlDoc);
+            return noteList.Notes;
+        }
+    }
+}

--- a/PivotalTrackerAPI/Domain/Model/PivotalNoteList.cs
+++ b/PivotalTrackerAPI/Domain/Model/PivotalNoteList.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace PivotalTrackerAPI.Domain.Model
+{
+    ///<summary>
+    /// Container for a note list
+    ///</summary>
+    [XmlRoot("notes")]
+    public class PivotalNoteList
+    {
+        ///<summary>
+        /// List of notes
+        ///</summary>
+        [XmlElement("note")]
+        public List<PivotalNote> Notes { get; set; }
+    }
+}

--- a/PivotalTrackerAPI/Domain/Model/PivotalStory.cs
+++ b/PivotalTrackerAPI/Domain/Model/PivotalStory.cs
@@ -325,6 +325,13 @@ namespace PivotalTrackerAPI.Domain.Model
     [XmlIgnore]
     public IList<PivotalTask> Tasks { get; set; }
 
+    /// <summary>
+    /// The cached list of notes for the story.  Be sure to use LoadNotes before calling this.  Once that method is called, use this property to access previously retrieved tasks
+    /// </summary>
+    /// <remarks>If you set this property and intend to save it, you have to then iterate the collection of notes and call add yourself or set the option when creating the story</remarks>
+    [XmlIgnore]
+    public IList<PivotalNote> Notes { get; set; }
+
     #endregion
 
     #endregion
@@ -390,6 +397,21 @@ namespace PivotalTrackerAPI.Domain.Model
     {
       Tasks = PivotalTask.FetchTasks(user, ProjectId.GetValueOrDefault(), Id.GetValueOrDefault(), "");
       return Tasks;
+    }
+
+    #endregion
+
+    #region Note Operations
+
+    /// <summary>
+    /// Updates the cache of tasks for the story and returns the list
+    /// </summary>
+    /// <param name="user">The user to get the ApiToken from</param>
+    /// <returns></returns>
+    public IList<PivotalNote> LoadNotes(PivotalUser user)
+    {
+        Notes = PivotalNote.FetchNotes(user, ProjectId.GetValueOrDefault(), Id.GetValueOrDefault(), "");
+        return Notes;
     }
 
     #endregion

--- a/PivotalTrackerAPI/Domain/Model/PivotalStory.cs
+++ b/PivotalTrackerAPI/Domain/Model/PivotalStory.cs
@@ -371,7 +371,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// <returns>the stories for the project</returns>
     public static PivotalStory FetchStory(PivotalUser user, int projectId, string storyId)
     {
-      string url = String.Format("{0}/projects/{1}/story/{2}?token={3}", PivotalService.BaseUrl, projectId.ToString(), storyId, user.ApiToken);
+      string url = String.Format("{0}/projects/{1}/stories/{2}?token={3}", PivotalService.BaseUrl, projectId.ToString(), storyId, user.ApiToken);
       XmlDocument xmlDoc = PivotalService.GetData(url);
       PivotalStory story = SerializationHelper.DeserializeFromXmlDocument<PivotalStory>(xmlDoc);
       return story;
@@ -449,7 +449,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// <returns>The updated story instance</returns>
     public static PivotalStory UpdateStory(PivotalUser user, string projectId, PivotalStory story)
     {
-      string url = String.Format("{0}/projects/{1}/story/{2}?token={3}", PivotalService.BaseUrl, projectId, story.Id, user.ApiToken);
+      string url = String.Format("{0}/projects/{1}/stories/{2}?token={3}", PivotalService.BaseUrl, projectId, story.Id, user.ApiToken);
       XmlDocument xml = SerializationHelper.SerializeToXmlDocument<PivotalStory>(story);
       string storyXml = PivotalService.CleanXmlForSubmission(xml, "//story", ExcludeNodesOnSubmit, true);
       XmlDocument response = PivotalService.SubmitData(url, storyXml, ServiceMethod.PUT);
@@ -482,7 +482,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// <returns>The story that was deleted</returns>
     public static PivotalStory DeleteStory(PivotalUser user, string projectId, PivotalStory story)
     {
-      string url = String.Format("{0}/projects/{1}/story/{2}?token={3}", PivotalService.BaseUrl, projectId, story.Id, user.ApiToken);
+      string url = String.Format("{0}/projects/{1}/stories/{2}?token={3}", PivotalService.BaseUrl, projectId, story.Id, user.ApiToken);
       XmlDocument xml = SerializationHelper.SerializeToXmlDocument<PivotalStory>(story);
       string storyXml = PivotalService.CleanXmlForSubmission(xml, "//story", ExcludeNodesOnSubmit, true);
       XmlDocument response = PivotalService.SubmitData(url, storyXml, ServiceMethod.DELETE);

--- a/PivotalTrackerAPI/Domain/Model/PivotalTask.cs
+++ b/PivotalTrackerAPI/Domain/Model/PivotalTask.cs
@@ -154,7 +154,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// <returns></returns>
     public static IList<PivotalTask> FetchTasks(PivotalUser user, int projectId, int storyId, string filter)
     {
-      string url = String.Format("{0}/projects/{1}/story/{2}/tasks?token={3}", PivotalService.BaseUrl, projectId, storyId, user.ApiToken);
+      string url = String.Format("{0}/projects/{1}/stories/{2}/tasks?token={3}", PivotalService.BaseUrl, projectId, storyId, user.ApiToken);
       if (!string.IsNullOrEmpty(filter))
         url += "&" + filter;
       XmlDocument xmlDoc = PivotalService.GetData(url);
@@ -194,7 +194,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// <returns>The updated task instance</returns>
     public static PivotalTask UpdateTask(PivotalUser user, int projectId, int storyId, PivotalTask task)
     {
-      string url = String.Format("{0}/projects/{1}/story/{2}/tasks/{3}?token={4}", PivotalService.BaseUrl, projectId, storyId, task.TaskId.GetValueOrDefault().ToString(), user.ApiToken);
+      string url = String.Format("{0}/projects/{1}/stories/{2}/tasks/{3}?token={4}", PivotalService.BaseUrl, projectId, storyId, task.TaskId.GetValueOrDefault().ToString(), user.ApiToken);
 
       XmlDocument xml = SerializationHelper.SerializeToXmlDocument<PivotalTask>(task);
 
@@ -232,7 +232,7 @@ namespace PivotalTrackerAPI.Domain.Model
     /// <returns></returns>
     public static PivotalTask DeleteTask(PivotalUser user, int projectId, int storyId, PivotalTask task)
     {
-      string url = String.Format("{0}/projects/{1}/story/{2}/task/{3}?token={4}", PivotalService.BaseUrl, projectId, storyId, task.TaskId.GetValueOrDefault().ToString(), user.ApiToken);
+      string url = String.Format("{0}/projects/{1}/stories/{2}/task/{3}?token={4}", PivotalService.BaseUrl, projectId, storyId, task.TaskId.GetValueOrDefault().ToString(), user.ApiToken);
 
       XmlDocument xml = SerializationHelper.SerializeToXmlDocument<PivotalTask>(task);
 

--- a/PivotalTrackerAPI/PivotalTrackerAPI.csproj
+++ b/PivotalTrackerAPI/PivotalTrackerAPI.csproj
@@ -37,6 +37,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Release\PivotalTrackerAPI.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -61,6 +62,8 @@
     <Compile Include="Domain\Model\PivotalIterationList.cs" />
     <Compile Include="Domain\Model\PivotalMembership.cs" />
     <Compile Include="Domain\Model\PivotalMembershipList.cs" />
+    <Compile Include="Domain\Model\PivotalNote.cs" />
+    <Compile Include="Domain\Model\PivotalNoteList.cs" />
     <Compile Include="Domain\Model\PivotalPerson.cs" />
     <Compile Include="Domain\Model\PivotalProject.cs" />
     <Compile Include="Domain\Model\PivotalProjectList.cs" />


### PR DESCRIPTION
Pivotal updated the way stories are requested; it was "story" and it is "stories".

For example: http://www.pivotaltracker.com/services/v3/projects/{projectId}/stories/{storyId}/notes?token={token}

I also updated a file to fix a build break.
